### PR TITLE
Remove catch strain attribute

### DIFF
--- a/osu.Server.DifficultyCalculator/DifficultyAttributeExtensions.cs
+++ b/osu.Server.DifficultyCalculator/DifficultyAttributeExtensions.cs
@@ -22,12 +22,14 @@ namespace osu.Server.DifficultyCalculator
                     yield return (5, osu.OverallDifficulty);
                     yield return (7, osu.ApproachRate);
                     yield return (9, osu.MaxCombo);
+                    yield return (11, attributes.StarRating);
 
                     break;
 
                 case TaikoDifficultyAttributes taiko:
                     yield return (9, taiko.MaxCombo);
                     yield return (13, taiko.GreatHitWindow);
+                    yield return (11, attributes.StarRating);
 
                     break;
 
@@ -40,11 +42,10 @@ namespace osu.Server.DifficultyCalculator
 
                 case ManiaDifficultyAttributes mania:
                     yield return (13, mania.GreatHitWindow);
+                    yield return (11, attributes.StarRating);
 
                     break;
             }
-
-            yield return (11, attributes.StarRating);
         }
     }
 }


### PR DESCRIPTION
Turns out this wasn't written to the db previously.

Path of least resistance is to use what was already in the db. I think since it matches SR it should really be using `Strain` instead of `Aim`, but that also requires osu-performance changes.

Unsure about the other modes - technically osu doesn't need it since it doesn't use it. But I've kept it for the time being since it's different to all other attributes in osu!'s case.