### PR TITLE
Temporarily disable health reporting

### DIFF
--- a/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
+++ b/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
-using Humanizer;
 using McMaster.Extensions.CommandLineUtils;
 
 namespace osu.Server.DifficultyCalculator.Commands
@@ -165,7 +163,7 @@ namespace osu.Server.DifficultyCalculator.Commands
 
         private void outputHealth()
         {
-            var process = Process.GetCurrentProcess();
+            // var process = Process.GetCurrentProcess();
             //reporter.Verbose($"Health p:{process.PrivateMemorySize64.Bytes()} v:{process.VirtualMemorySize64.Bytes()} w:{process.WorkingSet64.Bytes()}");
 
             string threadsString = string.Empty;

--- a/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
+++ b/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
@@ -166,7 +166,7 @@ namespace osu.Server.DifficultyCalculator.Commands
         private void outputHealth()
         {
             var process = Process.GetCurrentProcess();
-            reporter.Verbose($"Health p:{process.PrivateMemorySize64.Bytes()} v:{process.VirtualMemorySize64.Bytes()} w:{process.WorkingSet64.Bytes()}");
+            //reporter.Verbose($"Health p:{process.PrivateMemorySize64.Bytes()} v:{process.VirtualMemorySize64.Bytes()} w:{process.WorkingSet64.Bytes()}");
 
             string threadsString = string.Empty;
             for (int i = 0; i < threadBeatmapIds.Length; i++)


### PR DESCRIPTION
It's getting annoying having to disable this one locally every time.

I fixed it for them a few months back (https://github.com/Humanizr/Humanizer/pull/954), but there hasn't been a new nuget release yet.
Don''t really need this anymore so I don't see this as a big issue - it was mostly used for debugging purposes when diffcalc got into infinite loops, which isn't possible anymore.