### PR TITLE
Upgrade to net6 + update nuget packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 clone_depth: 1
 version: '{branch}-{build}'
-image: Visual Studio 2019
+image: Visual Studio 2022
 test: off
 
 environment:

--- a/osu.Server.DifficultyCalculator/BeatmapLoader.cs
+++ b/osu.Server.DifficultyCalculator/BeatmapLoader.cs
@@ -93,7 +93,7 @@ namespace osu.Server.DifficultyCalculator
             {
                 this.beatmap = beatmap;
 
-                switch (beatmap.BeatmapInfo.RulesetID)
+                switch (beatmap.BeatmapInfo.Ruleset.OnlineID)
                 {
                     case 0:
                         beatmap.BeatmapInfo.Ruleset = new OsuRuleset().RulesetInfo;

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -32,7 +31,7 @@ namespace osu.Server.DifficultyCalculator
             if (rulesetIds != null)
             {
                 foreach (int id in rulesetIds)
-                    processableRulesets.Add(available_rulesets.Single(r => r.RulesetInfo.ID == id));
+                    processableRulesets.Add(available_rulesets.Single(r => r.RulesetInfo.OnlineID == id));
             }
             else
             {
@@ -42,9 +41,7 @@ namespace osu.Server.DifficultyCalculator
 
         public void ProcessBeatmap(WorkingBeatmap beatmap)
         {
-            Debug.Assert(beatmap.BeatmapInfo.OnlineID != null);
-
-            int beatmapId = beatmap.BeatmapInfo.OnlineID.Value;
+            int beatmapId = beatmap.BeatmapInfo.OnlineID;
 
             try
             {
@@ -59,12 +56,12 @@ namespace osu.Server.DifficultyCalculator
 
                 using (var conn = Database.GetConnection())
                 {
-                    if (processConverts && beatmap.BeatmapInfo.RulesetID == 0)
+                    if (processConverts && beatmap.BeatmapInfo.Ruleset.OnlineID == 0)
                     {
                         foreach (var ruleset in processableRulesets)
                             computeDifficulty(beatmapId, beatmap, ruleset, conn);
                     }
-                    else if (processableRulesets.Any(r => r.RulesetInfo.ID == beatmap.BeatmapInfo.RulesetID))
+                    else if (processableRulesets.Any(r => r.RulesetInfo.OnlineID == beatmap.BeatmapInfo.Ruleset.OnlineID))
                         computeDifficulty(beatmapId, beatmap, beatmap.BeatmapInfo.Ruleset.CreateInstance(), conn);
                 }
             }
@@ -90,7 +87,7 @@ namespace osu.Server.DifficultyCalculator
                     new
                     {
                         BeatmapId = beatmapId,
-                        Mode = ruleset.RulesetInfo.ID,
+                        Mode = ruleset.RulesetInfo.OnlineID,
                         Mods = (int)legacyMod,
                         Diff = attribute.StarRating
                     });
@@ -104,7 +101,7 @@ namespace osu.Server.DifficultyCalculator
                         parameters.Add(new
                         {
                             BeatmapId = beatmapId,
-                            Mode = ruleset.RulesetInfo.ID,
+                            Mode = ruleset.RulesetInfo.OnlineID,
                             Mods = (int)legacyMod,
                             Attribute = mapping.attributeId,
                             Value = Convert.ToSingle(mapping.value)
@@ -127,10 +124,10 @@ namespace osu.Server.DifficultyCalculator
                     {
                         BeatmapId = beatmapId,
                         Diff = attribute.StarRating,
-                        AR = beatmap.Beatmap.BeatmapInfo.BaseDifficulty.ApproachRate,
-                        OD = beatmap.Beatmap.BeatmapInfo.BaseDifficulty.OverallDifficulty,
-                        HP = beatmap.Beatmap.BeatmapInfo.BaseDifficulty.DrainRate,
-                        CS = beatmap.Beatmap.BeatmapInfo.BaseDifficulty.CircleSize,
+                        AR = beatmap.Beatmap.BeatmapInfo.Difficulty.ApproachRate,
+                        OD = beatmap.Beatmap.BeatmapInfo.Difficulty.OverallDifficulty,
+                        HP = beatmap.Beatmap.BeatmapInfo.Difficulty.DrainRate,
+                        CS = beatmap.Beatmap.BeatmapInfo.Difficulty.CircleSize,
                         BPM = Math.Round(bpm, 2)
                     };
 

--- a/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
+++ b/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
@@ -2,7 +2,7 @@
     <Import Project="../osu.Server.props" />
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>osu.Server.DifficultyCalculator</AssemblyName>
         <RootNamespace>osu.Server.DifficultyCalculator</RootNamespace>
         <LangVersion>7.1</LangVersion>

--- a/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
+++ b/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
@@ -12,16 +12,16 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-        <PackageReference Include="MySqlConnector" Version="2.1.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.1207.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.1207.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2021.1207.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2021.1207.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2021.1207.0" />
+        <PackageReference Include="MySqlConnector" Version="2.1.6" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.205.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.205.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.205.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.205.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.205.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="appsettings.*.json">

--- a/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
+++ b/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
+++ b/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="DogStatsD-CSharp-Client" Version="7.0.0" />
-      <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2021.615.0 " />
+      <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.213.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
As per discussion in https://github.com/ppy/osu-beatmap-difficulty-lookup-cache/pull/4#discussion_r806957671, I've updated the usages to match however the sooner we can add a `RulesetStore` to replace all of this, the better.