### PR TITLE
Fix Dockerfile (update to .NET 6.0), add GitHub Workflow

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -1,0 +1,63 @@
+name: Build and publish
+
+on:
+  push:
+    branches:
+      - master
+      - release-diffcalc
+    tags:
+      - '*'
+
+jobs:
+  push_to_registry:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: pppy/osu-difficulty-calculator
+            context: ./
+            file: ./osu.Server.DifficultyCalculator/Dockerfile
+          - image: pppy/osu-queue-beatmap-processor
+            context: ./
+            file: ./osu.Server.Queues.BeatmapProcessor/Dockerfile
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ matrix.image }}
+          # generate Docker tags based on the following events/attributes
+          # on tag event: tag using git tag, and as latest if the tag doesn't contain hyphens (pre-releases)
+          # on push event: tag using git sha, branch name and as latest-dev
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+            type=raw,value=latest-dev,enable=${{ github.ref_type == 'branch' && github.ref_name == 'master' }}
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=${{ github.sha }},enable=${{ github.ref_type == 'branch' }}
+          flavor: |
+            latest=false
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/osu.Server.DifficultyCalculator/Dockerfile
+++ b/osu.Server.DifficultyCalculator/Dockerfile
@@ -1,4 +1,22 @@
-FROM mcr.microsoft.com/dotnet/runtime:5.0
-COPY bin/Release/net5.0/publish/ App/
-WORKDIR /App
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+WORKDIR /app
+
+# Handle project files and dependencies first for caching benefits
+COPY *.sln ./
+COPY osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj ./osu.Server.DifficultyCalculator/
+COPY osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj ./osu.Server.Queues.BeatmapProcessor/
+
+RUN dotnet restore
+
+# Copy everything else and build
+COPY . ./
+WORKDIR /app/osu.Server.DifficultyCalculator
+RUN dotnet publish -c Release -o out
+# get rid of bloat
+RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll ./out/osuTK.dll
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/runtime:6.0
+WORKDIR /app
+COPY --from=build-env /app/osu.Server.DifficultyCalculator/out .
 ENTRYPOINT ["dotnet", "osu.Server.DifficultyCalculator.dll"]

--- a/osu.Server.DifficultyCalculator/Dockerfile
+++ b/osu.Server.DifficultyCalculator/Dockerfile
@@ -13,7 +13,7 @@ COPY . ./
 WORKDIR /app/osu.Server.DifficultyCalculator
 RUN dotnet publish -c Release -o out
 # get rid of bloat
-RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll ./out/osuTK.dll
+RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/runtime:6.0

--- a/osu.Server.Queues.BeatmapProcessor/Dockerfile
+++ b/osu.Server.Queues.BeatmapProcessor/Dockerfile
@@ -13,7 +13,7 @@ COPY . ./
 WORKDIR /app/osu.Server.Queues.BeatmapProcessor
 RUN dotnet publish -c Release -o out
 # get rid of bloat
-RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll ./out/osuTK.dll
+RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/runtime:6.0

--- a/osu.Server.Queues.BeatmapProcessor/Dockerfile
+++ b/osu.Server.Queues.BeatmapProcessor/Dockerfile
@@ -1,4 +1,22 @@
-FROM mcr.microsoft.com/dotnet/runtime:5.0
-COPY bin/Release/net5.0/publish/ App/
-WORKDIR /App
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+WORKDIR /app
+
+# Handle project files and dependencies first for caching benefits
+COPY *.sln ./
+COPY osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj ./osu.Server.DifficultyCalculator/
+COPY osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj ./osu.Server.Queues.BeatmapProcessor/
+
+RUN dotnet restore
+
+# Copy everything else and build
+COPY . ./
+WORKDIR /app/osu.Server.Queues.BeatmapProcessor
+RUN dotnet publish -c Release -o out
+# get rid of bloat
+RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll ./out/osuTK.dll
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/runtime:6.0
+WORKDIR /app
+COPY --from=build-env /app/osu.Server.Queues.BeatmapProcessor/out .
 ENTRYPOINT ["dotnet", "osu.Server.Queues.BeatmapProcessor.dll"]


### PR DESCRIPTION
Builds and push to pppy/osu-difficulty-calculator and pppy/osu-queue-beatmap-processor on every git tag and push to master or release-diffcalc.

Docker tags are generated based on git commit sha, git tag or git branch depending on the push that triggered the workflow, `latest` when pushing a tag, `latest-dev` when pushing to master (similar to other repos).