### PR TITLE
Use server GC for beatmap processor queue

### DIFF
--- a/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
+++ b/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
@@ -5,6 +5,8 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
+        <ServerGarbageCollection>true</ServerGarbageCollection>
+        <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This is already enabled for the non-queue version, and previously provided a massive speedup there.