### PR TITLE
Update dependencies + write legacy scoring values to database

### DIFF
--- a/osu.Server.DifficultyCalculator/BeatmapLoader.cs
+++ b/osu.Server.DifficultyCalculator/BeatmapLoader.cs
@@ -121,7 +121,7 @@ namespace osu.Server.DifficultyCalculator
             }
 
             protected override IBeatmap GetBeatmap() => beatmap;
-            protected override Texture? GetBackground() => null;
+            public override Texture? GetBackground() => null;
             protected override Track? GetBeatmapTrack() => null;
             protected override ISkin? GetSkin() => null;
             public override Stream? GetStream(string storagePath) => null;

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -72,7 +72,10 @@ namespace osu.Server.DifficultyCalculator
 
         private void computeDifficulty(int beatmapId, WorkingBeatmap beatmap, Ruleset ruleset, MySqlConnection conn)
         {
-            foreach (var attribute in ruleset.CreateDifficultyCalculator(beatmap).CalculateAllLegacyCombinations())
+            var difficultyCalculator = ruleset.CreateDifficultyCalculator(beatmap);
+            difficultyCalculator.ComputeLegacyScoringValues = true;
+
+            foreach (var attribute in difficultyCalculator.CalculateAllLegacyCombinations())
             {
                 if (dryRun)
                     continue;

--- a/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
+++ b/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
@@ -10,18 +10,18 @@
         <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.0.123" />
+        <PackageReference Include="Dapper" Version="2.0.138" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="MySqlConnector" Version="2.1.13" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.927.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.927.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.927.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.927.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.927.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.614.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.614.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.614.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.614.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.614.1" />
     </ItemGroup>
     <ItemGroup>
         <None Update="appsettings.*.json">

--- a/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
+++ b/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-        <PackageReference Include="MySqlConnector" Version="2.3.0-beta.3" />
+        <PackageReference Include="MySqlConnector" Version="2.2.7" />
         <PackageReference Include="ppy.osu.Game" Version="2023.717.0" />
         <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.717.0" />
         <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.717.0" />

--- a/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
+++ b/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
@@ -10,18 +10,18 @@
         <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.0.138" />
+        <PackageReference Include="Dapper" Version="2.0.143" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-        <PackageReference Include="MySqlConnector" Version="2.1.13" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.614.1" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.614.1" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.614.1" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.614.1" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.614.1" />
+        <PackageReference Include="MySqlConnector" Version="2.3.0-beta.3" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.717.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.717.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.717.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.717.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.717.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="appsettings.*.json">

--- a/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
+++ b/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.0.138" />
+      <PackageReference Include="Dapper" Version="2.0.143" />
       <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1220.0" />
     </ItemGroup>
 

--- a/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
+++ b/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
@@ -10,9 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.0.123" />
-      <PackageReference Include="DogStatsD-CSharp-Client" Version="7.0.1" />
-      <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.812.0" />
+      <PackageReference Include="Dapper" Version="2.0.138" />
+      <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1220.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
As per https://github.com/ppy/osu-queue-score-statistics/pull/135, the database attributes are:
```sql
INSERT INTO osu_difficulty_attribs (attrib_id, name) VALUES (23, 'Legacy Accuracy Score'), (25, 'Legacy Combo Score'), (27, 'Legacy Bonus Score Ratio');
```