### PR TITLE
Remove `RUN_AS_SANDBOX_DOCKER` environment variable

### DIFF
--- a/osu.Server.DifficultyCalculator/AppSettings.cs
+++ b/osu.Server.DifficultyCalculator/AppSettings.cs
@@ -38,11 +38,6 @@ namespace osu.Server.DifficultyCalculator
         /// </summary>
         public static readonly bool SAVE_DOWNLOADED;
 
-        /// <summary>
-        /// Whether the difficulty command should wait for docker to be ready and perform automatic operations.
-        /// </summary>
-        public static readonly bool RUN_AS_SANDBOX_DOCKER;
-
         static AppSettings()
         {
             INSERT_BEATMAPS = Environment.GetEnvironmentVariable("INSERT_BEATMAPS") == "1";
@@ -52,8 +47,6 @@ namespace osu.Server.DifficultyCalculator
 
             BEATMAPS_PATH = Environment.GetEnvironmentVariable("BEATMAPS_PATH") ?? "osu";
             DOWNLOAD_PATH = Environment.GetEnvironmentVariable("DOWNLOAD_PATH") ?? "https://osu.ppy.sh/osu/{0}";
-
-            RUN_AS_SANDBOX_DOCKER = Environment.GetEnvironmentVariable("DOCKER") == "1";
         }
     }
 }


### PR DESCRIPTION
I originally implemented this environment variable to work with a previous version of my SR/PP testing workflow. It's completely undocumented and no longer used since its replacement ([diffcalc-sheet-generator](https://github.com/smoogipoo/diffcalc-sheet-generator)) orchestrates the processing stage externally to the difficulty calculator.

A similarly-named variable in elastic-indexer that served the same purpose was also removed a while ago: https://github.com/ppy/osu-elastic-indexer/pull/99