### PR TITLE
Write to legacy scoring attributes table

### DIFF
--- a/osu.Server.DifficultyCalculator.sln.DotSettings
+++ b/osu.Server.DifficultyCalculator.sln.DotSettings
@@ -128,6 +128,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMultipleEnumeration/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PrivateVariableCanBeMadeReadonly/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PublicConstructorInAbstractClass/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAnonymousTypePropertyName/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentDefaultValue/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArrayCreationExpression/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAttributeParentheses/@EntryIndexedValue">WARNING</s:String>

--- a/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
+++ b/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
@@ -41,6 +41,9 @@ namespace osu.Server.DifficultyCalculator.Commands
         [Option(CommandOptionType.NoValue, Template = "-dry|--dry-run", Description = "Whether to run the process without writing to the database.")]
         public bool DryRun { get; set; }
 
+        [Option(CommandOptionType.SingleValue, Template = "-pm|--processing-mode", Description = "The mode in which to process beatmaps.")]
+        public ProcessingModes ProcessingMode { get; set; }
+
         private int[] threadBeatmapIds = null!;
         private IReporter reporter = null!;
 
@@ -89,7 +92,21 @@ namespace osu.Server.DifficultyCalculator.Commands
                             // ensure the correct online id is set
                             beatmap.BeatmapInfo.OnlineID = beatmapId;
 
-                            calc.ProcessBeatmap(beatmap);
+                            switch (ProcessingMode)
+                            {
+                                case ProcessingModes.All:
+                                    calc.ProcessAll(beatmap);
+                                    break;
+
+                                case ProcessingModes.Difficulty:
+                                    calc.ProcessDifficulty(beatmap);
+                                    break;
+
+                                case ProcessingModes.ScoreAttributes:
+                                    calc.ProcessLegacyAttributes(beatmap);
+                                    break;
+                            }
+
                             reporter.Verbose($"Difficulty updated for beatmap {beatmapId}.");
                         }
                         catch (Exception e)
@@ -151,5 +168,12 @@ namespace osu.Server.DifficultyCalculator.Commands
         }
 
         protected abstract IEnumerable<int> GetBeatmaps();
+
+        public enum ProcessingModes
+        {
+            All,
+            Difficulty,
+            ScoreAttributes
+        }
     }
 }

--- a/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
+++ b/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
@@ -41,8 +41,8 @@ namespace osu.Server.DifficultyCalculator.Commands
         [Option(CommandOptionType.NoValue, Template = "-dry|--dry-run", Description = "Whether to run the process without writing to the database.")]
         public bool DryRun { get; set; }
 
-        [Option(CommandOptionType.SingleValue, Template = "-pm|--processing-mode", Description = "The mode in which to process beatmaps.")]
-        public ProcessingModes ProcessingMode { get; set; }
+        [Option(CommandOptionType.SingleValue, Template = "--processing-mode", Description = "The mode in which to process beatmaps.")]
+        public ProcessingModes ProcessingMode { get; set; } = ProcessingModes.All;
 
         private int[] threadBeatmapIds = null!;
         private IReporter reporter = null!;

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -11,6 +11,7 @@ using MySqlConnector;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring.Legacy;
 
 namespace osu.Server.DifficultyCalculator
@@ -162,8 +163,11 @@ namespace osu.Server.DifficultyCalculator
 
         private void processLegacyAttributes(int beatmapId, WorkingBeatmap beatmap, Ruleset ruleset, MySqlConnection conn)
         {
+            Mod? classicMod = ruleset.CreateMod<ModClassic>();
+            Mod[] mods = classicMod != null ? new[] { classicMod } : Array.Empty<Mod>();
+
             ILegacyScoreSimulator simulator = ((ILegacyRuleset)ruleset).CreateLegacyScoreSimulator();
-            LegacyScoreAttributes attributes = simulator.Simulate(beatmap, beatmap.GetPlayableBeatmap(ruleset.RulesetInfo));
+            LegacyScoreAttributes attributes = simulator.Simulate(beatmap, beatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods));
 
             if (dryRun)
                 return;

--- a/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
+++ b/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
@@ -10,18 +10,18 @@
         <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.0.143" />
+        <PackageReference Include="Dapper" Version="2.0.151" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
         <PackageReference Include="MySqlConnector" Version="2.2.7" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.717.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.717.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.717.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.717.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.717.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.928.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.928.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.928.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.928.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.928.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="appsettings.*.json">

--- a/osu.Server.Queues.BeatmapProcessor/BeatmapProcessor.cs
+++ b/osu.Server.Queues.BeatmapProcessor/BeatmapProcessor.cs
@@ -34,7 +34,7 @@ namespace osu.Server.Queues.BeatmapProcessor
                     // ensure the correct online id is set
                     working.BeatmapInfo.OnlineID = (int)beatmapId;
 
-                    calculator.ProcessDifficulty(working);
+                    calculator.ProcessAll(working);
                 }
             }
         }

--- a/osu.Server.Queues.BeatmapProcessor/BeatmapProcessor.cs
+++ b/osu.Server.Queues.BeatmapProcessor/BeatmapProcessor.cs
@@ -34,7 +34,7 @@ namespace osu.Server.Queues.BeatmapProcessor
                     // ensure the correct online id is set
                     working.BeatmapInfo.OnlineID = (int)beatmapId;
 
-                    calculator.ProcessBeatmap(working);
+                    calculator.ProcessDifficulty(working);
                 }
             }
         }

--- a/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
+++ b/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.0.143" />
-      <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1220.0" />
+      <PackageReference Include="Dapper" Version="2.0.151" />
+      <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.822.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/24779

```sql
CREATE TABLE `osu_beatmap_scoring_attribs` (
    `beatmap_id` mediumint unsigned NOT NULL,
    `mode` tinyint unsigned NOT NULL,
    `legacy_accuracy_score` int NOT NULL DEFAULT 0,
    `legacy_combo_score` bigint NOT NULL DEFAULT 0,
    `legacy_bonus_score_ratio` float NOT NULL DEFAULT 0,
    PRIMARY KEY (`beatmap_id`, `mode`)
);
```

This is structured in a way that you can run diffcalc in 3 modes with the `--processing-mode` option. This is with the expectation that there are going to be two instances running at once on the infrastructure (e.g. we could populate the scoring attributes without recalculating SR). By default, it processes both difficulty and scoring attribs, so this is no issue with the default args.