### PR TITLE
Allow specifying queue name & scope of calculation in queue processor

### DIFF
--- a/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
+++ b/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
@@ -42,7 +42,7 @@ namespace osu.Server.DifficultyCalculator.Commands
         public bool DryRun { get; set; }
 
         [Option(CommandOptionType.SingleValue, Template = "--processing-mode", Description = "The mode in which to process beatmaps.")]
-        public ProcessingModes ProcessingMode { get; set; } = ProcessingModes.All;
+        public ProcessingMode ProcessingMode { get; set; } = ProcessingMode.All;
 
         private int[] threadBeatmapIds = null!;
         private IReporter reporter = null!;
@@ -94,15 +94,15 @@ namespace osu.Server.DifficultyCalculator.Commands
 
                             switch (ProcessingMode)
                             {
-                                case ProcessingModes.All:
+                                case ProcessingMode.All:
                                     calc.ProcessAll(beatmap);
                                     break;
 
-                                case ProcessingModes.Difficulty:
+                                case ProcessingMode.Difficulty:
                                     calc.ProcessDifficulty(beatmap);
                                     break;
 
-                                case ProcessingModes.ScoreAttributes:
+                                case ProcessingMode.ScoreAttributes:
                                     calc.ProcessLegacyAttributes(beatmap);
                                     break;
                             }
@@ -168,12 +168,5 @@ namespace osu.Server.DifficultyCalculator.Commands
         }
 
         protected abstract IEnumerable<int> GetBeatmaps();
-
-        public enum ProcessingModes
-        {
-            All,
-            Difficulty,
-            ScoreAttributes
-        }
     }
 }

--- a/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
+++ b/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
@@ -92,20 +92,7 @@ namespace osu.Server.DifficultyCalculator.Commands
                             // ensure the correct online id is set
                             beatmap.BeatmapInfo.OnlineID = beatmapId;
 
-                            switch (ProcessingMode)
-                            {
-                                case ProcessingMode.All:
-                                    calc.ProcessAll(beatmap);
-                                    break;
-
-                                case ProcessingMode.Difficulty:
-                                    calc.ProcessDifficulty(beatmap);
-                                    break;
-
-                                case ProcessingMode.ScoreAttributes:
-                                    calc.ProcessLegacyAttributes(beatmap);
-                                    break;
-                            }
+                            calc.Process(beatmap, ProcessingMode);
 
                             reporter.Verbose($"Difficulty updated for beatmap {beatmapId}.");
                         }

--- a/osu.Server.DifficultyCalculator/Commands/ProcessingMode.cs
+++ b/osu.Server.DifficultyCalculator/Commands/ProcessingMode.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Server.DifficultyCalculator.Commands
+{
+    public enum ProcessingMode
+    {
+        All,
+        Difficulty,
+        ScoreAttributes
+    }
+}

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -13,6 +13,7 @@ using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring.Legacy;
+using osu.Server.DifficultyCalculator.Commands;
 
 namespace osu.Server.DifficultyCalculator
 {
@@ -40,10 +41,26 @@ namespace osu.Server.DifficultyCalculator
             }
         }
 
-        public void ProcessAll(WorkingBeatmap beatmap)
+        public void Process(WorkingBeatmap beatmap, ProcessingMode mode)
         {
-            ProcessDifficulty(beatmap);
-            ProcessLegacyAttributes(beatmap);
+            switch (mode)
+            {
+                case ProcessingMode.All:
+                    ProcessDifficulty(beatmap);
+                    ProcessLegacyAttributes(beatmap);
+                    break;
+
+                case ProcessingMode.Difficulty:
+                    ProcessDifficulty(beatmap);
+                    break;
+
+                case ProcessingMode.ScoreAttributes:
+                    ProcessLegacyAttributes(beatmap);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported processing mode supplied");
+            }
         }
 
         public void ProcessDifficulty(WorkingBeatmap beatmap) => run(beatmap, processDifficulty);

--- a/osu.Server.Queues.BeatmapProcessor/BeatmapProcessor.cs
+++ b/osu.Server.Queues.BeatmapProcessor/BeatmapProcessor.cs
@@ -3,21 +3,24 @@
 
 using Dapper;
 using osu.Server.DifficultyCalculator;
+using osu.Server.DifficultyCalculator.Commands;
 using osu.Server.QueueProcessor;
 
 namespace osu.Server.Queues.BeatmapProcessor
 {
     internal class BeatmapProcessor : QueueProcessor<BeatmapItem>
     {
+        private readonly ProcessingMode processingMode;
         private readonly ServerDifficultyCalculator calculator;
 
-        public BeatmapProcessor()
+        public BeatmapProcessor(ProcessingMode processingMode, string queueName)
             : base(new QueueConfiguration
             {
-                InputQueueName = "beatmap",
+                InputQueueName = queueName,
                 MaxInFlightItems = 4,
             })
         {
+            this.processingMode = processingMode;
             calculator = new ServerDifficultyCalculator(new[] { 0, 1, 2, 3 });
         }
 
@@ -34,7 +37,7 @@ namespace osu.Server.Queues.BeatmapProcessor
                     // ensure the correct online id is set
                     working.BeatmapInfo.OnlineID = (int)beatmapId;
 
-                    calculator.ProcessAll(working);
+                    calculator.Process(working, processingMode);
                 }
             }
         }

--- a/osu.Server.Queues.BeatmapProcessor/Program.cs
+++ b/osu.Server.Queues.BeatmapProcessor/Program.cs
@@ -1,13 +1,30 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Server.DifficultyCalculator.Commands;
+
 namespace osu.Server.Queues.BeatmapProcessor
 {
+    [Command]
     public class Program
     {
-        public static void Main(string[] args)
+        [Argument(0, "mode", "The target mode to process the beatmaps from the queue in.")]
+        [UsedImplicitly]
+        private ProcessingMode processingMode { get; } = ProcessingMode.All;
+
+        [Argument(1, "queue-name", "The name of the queue to watch. The `osu-queue:` prefix must be omitted.")]
+        [UsedImplicitly]
+        private string queueName { get; } = "beatmap";
+
+        public static void Main(string[] args) => CommandLineApplication.Execute<Program>(args);
+
+        [UsedImplicitly]
+        public int OnExecute(CommandLineApplication app)
         {
-            new BeatmapProcessor().Run();
+            new BeatmapProcessor(processingMode, queueName).Run();
+            return 0;
         }
     }
 }


### PR DESCRIPTION
The end goal of this pull request is to be able to split queue processing of beatmaps into two parts: one that populates difficulty attributes exclusively, and one that populates scoring attributes only.

As per usage instructions:

```
Usage: osu.Server.Queues.BeatmapProcessor [options] <mode> <queue-name>

Arguments:
  mode          The target mode to process the beatmaps from the queue in.
                Allowed values are: All, Difficulty, ScoreAttributes.
                Default value is: All.
  queue-name    The name of the queue to watch. The `osu-queue:` prefix must be omitted.
                Default value is: beatmap.

Options:
  -?|-h|--help  Show help information.
```

So you'd potentially have two instances of the processor running:

```
$ dotnet run osu.Server.Queues.BeatmapProcessor Difficulty beatmap-difficulty
$ dotnet run osu.Server.Queues.BeatmapProcessor ScoreAttributes beatmap-score-attributes
```

correspondingly. The `queue-name` param feels a little redundant maybe and could be replaced by an implicit hardcoded mapping, but this felt better?

Notably, when the processor is ran without arguments, the defaults are such that it falls back to the current mode of operations with no change in behaviour (everything from `osu-queue:beatmap` is processed).

I did test this semi-manually on a local environment by pushing items to the queue manually via `redis-cli`. To make use of the params added here the sending end will have to be adjusted, but I am not sure that is something that I have access to at present.