### PR TITLE
Add new score attribute columns

### DIFF
--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -174,16 +174,18 @@ namespace osu.Server.DifficultyCalculator
                 return;
 
             conn.Execute(
-                "INSERT INTO `osu_beatmap_scoring_attribs` (`beatmap_id`, `mode`, `legacy_accuracy_score`, `legacy_combo_score`, `legacy_bonus_score_ratio`) "
-                + "VALUES (@BeatmapId, @Mode, @AccuracyScore, @ComboScore, @BonusScoreRatio) "
-                + "ON DUPLICATE KEY UPDATE `legacy_accuracy_score` = @AccuracyScore, `legacy_combo_score` = @ComboScore, `legacy_bonus_score_ratio` = @BonusScoreRatio",
+                "INSERT INTO `osu_beatmap_scoring_attribs` (`beatmap_id`, `mode`, `legacy_accuracy_score`, `legacy_combo_score`, `legacy_bonus_score_ratio`, `legacy_bonus_score`, `max_combo`) "
+                + "VALUES (@BeatmapId, @Mode, @AccuracyScore, @ComboScore, @BonusScoreRatio, @BonusScore, @MaxCombo) "
+                + "ON DUPLICATE KEY UPDATE `legacy_accuracy_score` = @AccuracyScore, `legacy_combo_score` = @ComboScore, `legacy_bonus_score_ratio` = @BonusScoreRatio, `legacy_bonus_score` = @BonusScore, `max_combo` = @MaxCombo",
                 new
                 {
                     BeatmapId = beatmapId,
                     Mode = ruleset.RulesetInfo.OnlineID,
                     AccuracyScore = attributes.AccuracyScore,
                     ComboScore = attributes.ComboScore,
-                    BonusScoreRatio = attributes.BonusScoreRatio
+                    BonusScoreRatio = attributes.BonusScoreRatio,
+                    BonusScore = attributes.BonusScore,
+                    MaxCombo = attributes.MaxCombo
                 });
         }
 

--- a/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
+++ b/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
@@ -17,11 +17,11 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
         <PackageReference Include="MySqlConnector" Version="2.2.7" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.928.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.928.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.928.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.928.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.928.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.1213.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1213.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1213.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1213.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1213.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="appsettings.*.json">

--- a/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
+++ b/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.0.151" />
-      <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.822.0" />
+      <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.1207.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Prereqs:
- [x] osu! nuget release / package update.

```sql
CREATE TABLE IF NOT EXISTS `osu_beatmap_scoring_attribs` (
  `beatmap_id` mediumint unsigned NOT NULL,
  `mode` tinyint unsigned NOT NULL,
  `legacy_accuracy_score` int NOT NULL DEFAULT 0,
  `legacy_combo_score` bigint NOT NULL DEFAULT 0,
  `legacy_bonus_score_ratio` float NOT NULL DEFAULT 0,
  `legacy_bonus_score` int NOT NULL DEFAULT 0,
  `max_combo` int NOT NULL DEFAULT 0,
  PRIMARY KEY (`beatmap_id`, `mode`)
);
```