### PR TITLE
Skip writing unranked beatmaps to `osu_beatmap_difficulty_attribs`

### DIFF
--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -116,8 +116,8 @@ namespace osu.Server.DifficultyCalculator
                     + "ON DUPLICATE KEY UPDATE `diff_unified` = @Diff",
                     new
                     {
-                        BeatmapId = item.Beatmap.BeatmapInfo.OnlineID,
-                        Mode = item.Ruleset.RulesetInfo.OnlineID,
+                        BeatmapId = item.BeatmapID,
+                        Mode = item.RulesetID,
                         Mods = (int)legacyMods,
                         Diff = attribute.StarRating
                     });
@@ -130,8 +130,8 @@ namespace osu.Server.DifficultyCalculator
                     {
                         parameters.Add(new
                         {
-                            BeatmapId = item.Beatmap.BeatmapInfo.OnlineID,
-                            Mode = item.Ruleset.RulesetInfo.OnlineID,
+                            BeatmapId = item.BeatmapID,
+                            Mode = item.RulesetID,
                             Mods = (int)legacyMods,
                             Attribute = mapping.attributeId,
                             Value = Convert.ToSingle(mapping.value)
@@ -152,7 +152,7 @@ namespace osu.Server.DifficultyCalculator
 
                     object param = new
                     {
-                        BeatmapId = item.Beatmap.BeatmapInfo.OnlineID,
+                        BeatmapId = item.BeatmapID,
                         Diff = attribute.StarRating,
                         AR = item.Beatmap.Beatmap.BeatmapInfo.Difficulty.ApproachRate,
                         OD = item.Beatmap.Beatmap.BeatmapInfo.Difficulty.OverallDifficulty,
@@ -201,8 +201,8 @@ namespace osu.Server.DifficultyCalculator
                 + "ON DUPLICATE KEY UPDATE `legacy_accuracy_score` = @AccuracyScore, `legacy_combo_score` = @ComboScore, `legacy_bonus_score_ratio` = @BonusScoreRatio, `legacy_bonus_score` = @BonusScore, `max_combo` = @MaxCombo",
                 new
                 {
-                    BeatmapId = item.Beatmap.BeatmapInfo.OnlineID,
-                    Mode = item.Ruleset.RulesetInfo.OnlineID,
+                    BeatmapId = item.BeatmapID,
+                    Mode = item.RulesetID,
                     AccuracyScore = attributes.AccuracyScore,
                     ComboScore = attributes.ComboScore,
                     BonusScoreRatio = attributes.BonusScoreRatio,
@@ -234,6 +234,10 @@ namespace osu.Server.DifficultyCalculator
             return rulesetsToProcess;
         }
 
-        private readonly record struct ProcessableItem(WorkingBeatmap Beatmap, Ruleset Ruleset, bool Ranked);
+        private readonly record struct ProcessableItem(WorkingBeatmap Beatmap, Ruleset Ruleset, bool Ranked)
+        {
+            public int BeatmapID => Beatmap.BeatmapInfo.OnlineID;
+            public int RulesetID => Ruleset.RulesetInfo.OnlineID;
+        }
     }
 }

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -183,9 +183,6 @@ namespace osu.Server.DifficultyCalculator
 
         private void processLegacyAttributes(ProcessableItem item, MySqlConnection conn)
         {
-            if (!item.Ranked)
-                return;
-
             Mod? classicMod = item.Ruleset.CreateMod<ModClassic>();
             Mod[] mods = classicMod != null ? new[] { classicMod } : Array.Empty<Mod>();
 

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -122,7 +122,7 @@ namespace osu.Server.DifficultyCalculator
                         Diff = attribute.StarRating
                     });
 
-                if (!AppSettings.SKIP_INSERT_ATTRIBUTES)
+                if (item.Ranked && !AppSettings.SKIP_INSERT_ATTRIBUTES)
                 {
                     var parameters = new List<object>();
 

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -154,10 +154,10 @@ namespace osu.Server.DifficultyCalculator
                     {
                         BeatmapId = item.BeatmapID,
                         Diff = attribute.StarRating,
-                        AR = item.Beatmap.Beatmap.BeatmapInfo.Difficulty.ApproachRate,
-                        OD = item.Beatmap.Beatmap.BeatmapInfo.Difficulty.OverallDifficulty,
-                        HP = item.Beatmap.Beatmap.BeatmapInfo.Difficulty.DrainRate,
-                        CS = item.Beatmap.Beatmap.BeatmapInfo.Difficulty.CircleSize,
+                        AR = item.Beatmap.BeatmapInfo.Difficulty.ApproachRate,
+                        OD = item.Beatmap.BeatmapInfo.Difficulty.OverallDifficulty,
+                        HP = item.Beatmap.BeatmapInfo.Difficulty.DrainRate,
+                        CS = item.Beatmap.BeatmapInfo.Difficulty.CircleSize,
                         BPM = Math.Round(bpm, 2),
                         MaxCombo = attribute.MaxCombo,
                     };


### PR DESCRIPTION
A while back, we trimmed all attributes for unranked beatmaps from the `osu_beatmap_difficulty_attribs` table. This was done for space-saving reasons.

_Without_ this PR, these attributes are still being written for all new beatmaps and for full reprocesses.

Of particular importance, note that:
- I haven't stopped writing of scoring attribs. It may be safe to not write them too, but I would rather not break anything there for now. This table is quite small anyway.
- This still writes to `osu_beatmap_difficulty`, where we may have decided to keep the star rating written to during the previous trimming.
- It now always queries `osu_beatmaps`, once for each beatmap. I'm hoping the overhead here is pretty minimal.

Haven't really tested this yet.