### PR TITLE
Update hitobject counts in `osu_beatmaps` table

### DIFF
--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -103,7 +103,7 @@ namespace osu.Server.DifficultyCalculator
 
         private void processDifficulty(ProcessableItem item, MySqlConnection conn)
         {
-            foreach (var attribute in item.Ruleset.CreateDifficultyCalculator(item.Beatmap).CalculateAllLegacyCombinations())
+            foreach (var attribute in item.Ruleset.CreateDifficultyCalculator(item.WorkingBeatmap).CalculateAllLegacyCombinations())
             {
                 if (dryRun)
                     continue;
@@ -145,19 +145,19 @@ namespace osu.Server.DifficultyCalculator
                         parameters.ToArray());
                 }
 
-                if (legacyMods == LegacyMods.None && item.Ruleset.RulesetInfo.Equals(item.Beatmap.BeatmapInfo.Ruleset))
+                if (legacyMods == LegacyMods.None && item.Ruleset.RulesetInfo.Equals(item.WorkingBeatmap.BeatmapInfo.Ruleset))
                 {
-                    double beatLength = item.Beatmap.Beatmap.GetMostCommonBeatLength();
+                    double beatLength = item.WorkingBeatmap.Beatmap.GetMostCommonBeatLength();
                     double bpm = beatLength > 0 ? 60000 / beatLength : 0;
 
                     object param = new
                     {
                         BeatmapId = item.BeatmapID,
                         Diff = attribute.StarRating,
-                        AR = item.Beatmap.BeatmapInfo.Difficulty.ApproachRate,
-                        OD = item.Beatmap.BeatmapInfo.Difficulty.OverallDifficulty,
-                        HP = item.Beatmap.BeatmapInfo.Difficulty.DrainRate,
-                        CS = item.Beatmap.BeatmapInfo.Difficulty.CircleSize,
+                        AR = item.WorkingBeatmap.BeatmapInfo.Difficulty.ApproachRate,
+                        OD = item.WorkingBeatmap.BeatmapInfo.Difficulty.OverallDifficulty,
+                        HP = item.WorkingBeatmap.BeatmapInfo.Difficulty.DrainRate,
+                        CS = item.WorkingBeatmap.BeatmapInfo.Difficulty.CircleSize,
                         BPM = Math.Round(bpm, 2),
                         MaxCombo = attribute.MaxCombo,
                     };
@@ -187,7 +187,7 @@ namespace osu.Server.DifficultyCalculator
             Mod[] mods = classicMod != null ? new[] { classicMod } : Array.Empty<Mod>();
 
             ILegacyScoreSimulator simulator = ((ILegacyRuleset)item.Ruleset).CreateLegacyScoreSimulator();
-            LegacyScoreAttributes attributes = simulator.Simulate(item.Beatmap, item.Beatmap.GetPlayableBeatmap(item.Ruleset.RulesetInfo, mods));
+            LegacyScoreAttributes attributes = simulator.Simulate(item.WorkingBeatmap, item.WorkingBeatmap.GetPlayableBeatmap(item.Ruleset.RulesetInfo, mods));
 
             if (dryRun)
                 return;
@@ -231,9 +231,9 @@ namespace osu.Server.DifficultyCalculator
             return rulesetsToProcess;
         }
 
-        private readonly record struct ProcessableItem(WorkingBeatmap Beatmap, Ruleset Ruleset, bool Ranked)
+        private readonly record struct ProcessableItem(WorkingBeatmap WorkingBeatmap, Ruleset Ruleset, bool Ranked)
         {
-            public int BeatmapID => Beatmap.BeatmapInfo.OnlineID;
+            public int BeatmapID => WorkingBeatmap.BeatmapInfo.OnlineID;
             public int RulesetID => Ruleset.RulesetInfo.OnlineID;
         }
     }

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -67,7 +67,7 @@ namespace osu.Server.DifficultyCalculator
 
         public void ProcessLegacyAttributes(WorkingBeatmap beatmap) => run(beatmap, processLegacyAttributes);
 
-        private void run(WorkingBeatmap beatmap, Action<ProcessableBeatmap, MySqlConnection> callback)
+        private void run(WorkingBeatmap beatmap, Action<ProcessableItem, MySqlConnection> callback)
         {
             try
             {
@@ -89,10 +89,10 @@ namespace osu.Server.DifficultyCalculator
                     if (processConverts && beatmap.BeatmapInfo.Ruleset.OnlineID == 0)
                     {
                         foreach (var ruleset in processableRulesets)
-                            callback(new ProcessableBeatmap(beatmap, ruleset, ranked), conn);
+                            callback(new ProcessableItem(beatmap, ruleset, ranked), conn);
                     }
                     else if (processableRulesets.Any(r => r.RulesetInfo.OnlineID == beatmap.BeatmapInfo.Ruleset.OnlineID))
-                        callback(new ProcessableBeatmap(beatmap, beatmap.BeatmapInfo.Ruleset.CreateInstance(), ranked), conn);
+                        callback(new ProcessableItem(beatmap, beatmap.BeatmapInfo.Ruleset.CreateInstance(), ranked), conn);
                 }
             }
             catch (Exception e)
@@ -101,14 +101,14 @@ namespace osu.Server.DifficultyCalculator
             }
         }
 
-        private void processDifficulty(ProcessableBeatmap beatmap, MySqlConnection conn)
+        private void processDifficulty(ProcessableItem item, MySqlConnection conn)
         {
-            foreach (var attribute in beatmap.Ruleset.CreateDifficultyCalculator(beatmap.Beatmap).CalculateAllLegacyCombinations())
+            foreach (var attribute in item.Ruleset.CreateDifficultyCalculator(item.Beatmap).CalculateAllLegacyCombinations())
             {
                 if (dryRun)
                     continue;
 
-                LegacyMods legacyMods = beatmap.Ruleset.ConvertToLegacyMods(attribute.Mods);
+                LegacyMods legacyMods = item.Ruleset.ConvertToLegacyMods(attribute.Mods);
 
                 conn.Execute(
                     "INSERT INTO `osu_beatmap_difficulty` (`beatmap_id`, `mode`, `mods`, `diff_unified`) "
@@ -116,13 +116,13 @@ namespace osu.Server.DifficultyCalculator
                     + "ON DUPLICATE KEY UPDATE `diff_unified` = @Diff",
                     new
                     {
-                        BeatmapId = beatmap.BeatmapID,
-                        Mode = beatmap.RulesetID,
+                        BeatmapId = item.BeatmapID,
+                        Mode = item.RulesetID,
                         Mods = (int)legacyMods,
                         Diff = attribute.StarRating
                     });
 
-                if (beatmap.Ranked && !AppSettings.SKIP_INSERT_ATTRIBUTES)
+                if (item.Ranked && !AppSettings.SKIP_INSERT_ATTRIBUTES)
                 {
                     var parameters = new List<object>();
 
@@ -130,8 +130,8 @@ namespace osu.Server.DifficultyCalculator
                     {
                         parameters.Add(new
                         {
-                            BeatmapId = beatmap.BeatmapID,
-                            Mode = beatmap.RulesetID,
+                            BeatmapId = item.BeatmapID,
+                            Mode = item.RulesetID,
                             Mods = (int)legacyMods,
                             Attribute = mapping.attributeId,
                             Value = Convert.ToSingle(mapping.value)
@@ -145,19 +145,19 @@ namespace osu.Server.DifficultyCalculator
                         parameters.ToArray());
                 }
 
-                if (legacyMods == LegacyMods.None && beatmap.Ruleset.RulesetInfo.Equals(beatmap.Beatmap.BeatmapInfo.Ruleset))
+                if (legacyMods == LegacyMods.None && item.Ruleset.RulesetInfo.Equals(item.Beatmap.BeatmapInfo.Ruleset))
                 {
-                    double beatLength = beatmap.Beatmap.Beatmap.GetMostCommonBeatLength();
+                    double beatLength = item.Beatmap.Beatmap.GetMostCommonBeatLength();
                     double bpm = beatLength > 0 ? 60000 / beatLength : 0;
 
                     object param = new
                     {
-                        BeatmapId = beatmap.BeatmapID,
+                        BeatmapId = item.BeatmapID,
                         Diff = attribute.StarRating,
-                        AR = beatmap.Beatmap.BeatmapInfo.Difficulty.ApproachRate,
-                        OD = beatmap.Beatmap.BeatmapInfo.Difficulty.OverallDifficulty,
-                        HP = beatmap.Beatmap.BeatmapInfo.Difficulty.DrainRate,
-                        CS = beatmap.Beatmap.BeatmapInfo.Difficulty.CircleSize,
+                        AR = item.Beatmap.BeatmapInfo.Difficulty.ApproachRate,
+                        OD = item.Beatmap.BeatmapInfo.Difficulty.OverallDifficulty,
+                        HP = item.Beatmap.BeatmapInfo.Difficulty.DrainRate,
+                        CS = item.Beatmap.BeatmapInfo.Difficulty.CircleSize,
                         BPM = Math.Round(bpm, 2),
                         MaxCombo = attribute.MaxCombo,
                     };
@@ -181,13 +181,13 @@ namespace osu.Server.DifficultyCalculator
             }
         }
 
-        private void processLegacyAttributes(ProcessableBeatmap beatmap, MySqlConnection conn)
+        private void processLegacyAttributes(ProcessableItem item, MySqlConnection conn)
         {
-            Mod? classicMod = beatmap.Ruleset.CreateMod<ModClassic>();
+            Mod? classicMod = item.Ruleset.CreateMod<ModClassic>();
             Mod[] mods = classicMod != null ? new[] { classicMod } : Array.Empty<Mod>();
 
-            ILegacyScoreSimulator simulator = ((ILegacyRuleset)beatmap.Ruleset).CreateLegacyScoreSimulator();
-            LegacyScoreAttributes attributes = simulator.Simulate(beatmap.Beatmap, beatmap.Beatmap.GetPlayableBeatmap(beatmap.Ruleset.RulesetInfo, mods));
+            ILegacyScoreSimulator simulator = ((ILegacyRuleset)item.Ruleset).CreateLegacyScoreSimulator();
+            LegacyScoreAttributes attributes = simulator.Simulate(item.Beatmap, item.Beatmap.GetPlayableBeatmap(item.Ruleset.RulesetInfo, mods));
 
             if (dryRun)
                 return;
@@ -198,8 +198,8 @@ namespace osu.Server.DifficultyCalculator
                 + "ON DUPLICATE KEY UPDATE `legacy_accuracy_score` = @AccuracyScore, `legacy_combo_score` = @ComboScore, `legacy_bonus_score_ratio` = @BonusScoreRatio, `legacy_bonus_score` = @BonusScore, `max_combo` = @MaxCombo",
                 new
                 {
-                    BeatmapId = beatmap.BeatmapID,
-                    Mode = beatmap.RulesetID,
+                    BeatmapId = item.BeatmapID,
+                    Mode = item.RulesetID,
                     AccuracyScore = attributes.AccuracyScore,
                     ComboScore = attributes.ComboScore,
                     BonusScoreRatio = attributes.BonusScoreRatio,
@@ -231,7 +231,7 @@ namespace osu.Server.DifficultyCalculator
             return rulesetsToProcess;
         }
 
-        private readonly record struct ProcessableBeatmap(WorkingBeatmap Beatmap, Ruleset Ruleset, bool Ranked)
+        private readonly record struct ProcessableItem(WorkingBeatmap Beatmap, Ruleset Ruleset, bool Ranked)
         {
             public int BeatmapID => Beatmap.BeatmapInfo.OnlineID;
             public int RulesetID => Ruleset.RulesetInfo.OnlineID;

--- a/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
+++ b/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
@@ -13,15 +13,15 @@
         <PackageReference Include="Dapper" Version="2.1.44" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-        <PackageReference Include="MySqlConnector" Version="2.3.7" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.1104.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.1104.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.1104.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.1104.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.1104.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+        <PackageReference Include="MySqlConnector" Version="2.4.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.1115.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.1115.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.1115.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.1115.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.1115.1" />
     </ItemGroup>
     <ItemGroup>
         <None Update="appsettings.*.json">

--- a/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
+++ b/osu.Server.Queues.BeatmapProcessor/osu.Server.Queues.BeatmapProcessor.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.1.44" />
-      <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.507.0" />
+      <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.1111.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/30578

See discussion starting from https://discord.com/channels/188630481301012481/380598781432823815/1304293217533165609

tl;dr: We found [this beatmap](https://osu.ppy.sh/beatmapsets/29#osu/97) was listed as having 18 sliders when in reality it has 28. This count is directly [read+used](https://github.com/ppy/osu/blob/322df72cce308c5bd4d34dc983e432558a1d1715/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs#L129-L131) by the osu!-ruleset pp processor. Other older beatmaps likely also have incorrect counts.

Of note: Writing `countTotal` in particular affects [one achievement](https://github.com/ppy/osu-queue-score-statistics-private/blob/4405b2bfb855d68a449426f8064fbd701070ab79/osu.Server.Queues.ScoreStatisticsProcessor.HushHushMedals/HushHushMedalAwarder.cs#L696-L697), but is only used to prevent cheese. [`osu-web-10`](https://github.com/peppy/osu-web-10/blob/9f9b11ce1bc49268c3f2a00a263e346ff86737d9/www/web/osu-osz2-bmsubmit-upload.php#L149) writes this value as `1 * circles + 2 * sliders + 3 * spinners` for some reason.