### PR TITLE
Add timeout for attribute processing

### DIFF
--- a/osu.Server.DifficultyCalculator/AppSettings.cs
+++ b/osu.Server.DifficultyCalculator/AppSettings.cs
@@ -38,6 +38,12 @@ namespace osu.Server.DifficultyCalculator
         /// </summary>
         public static readonly bool SAVE_DOWNLOADED;
 
+        /// <summary>
+        /// The amount of time (in milliseconds) to allow for processing difficulty attributes before timing out.
+        /// This is per-ruleset and shared amongst all mod combinations within the ruleset.
+        /// </summary>
+        public static readonly int ATTRIBUTE_PROCESSING_TIMEOUT = 30000;
+
         static AppSettings()
         {
             INSERT_BEATMAPS = Environment.GetEnvironmentVariable("INSERT_BEATMAPS") == "1";
@@ -47,6 +53,8 @@ namespace osu.Server.DifficultyCalculator
 
             BEATMAPS_PATH = Environment.GetEnvironmentVariable("BEATMAPS_PATH") ?? "osu";
             DOWNLOAD_PATH = Environment.GetEnvironmentVariable("BEATMAP_DOWNLOAD_PATH") ?? "https://osu.ppy.sh/osu/{0}";
+
+            ATTRIBUTE_PROCESSING_TIMEOUT = int.TryParse(Environment.GetEnvironmentVariable("ATTRIBUTE_PROCESSING_TIMEOUT"), out int timeout) ? timeout : ATTRIBUTE_PROCESSING_TIMEOUT;
         }
     }
 }

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Dapper;
 using MySqlConnector;
 using osu.Game.Beatmaps;
@@ -105,7 +106,9 @@ namespace osu.Server.DifficultyCalculator
 
         private void processDifficulty(ProcessableItem item, MySqlConnection conn)
         {
-            foreach (var attribute in item.Ruleset.CreateDifficultyCalculator(item.WorkingBeatmap).CalculateAllLegacyCombinations())
+            using var timedCancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(AppSettings.ATTRIBUTE_PROCESSING_TIMEOUT));
+
+            foreach (var attribute in item.Ruleset.CreateDifficultyCalculator(item.WorkingBeatmap).CalculateAllLegacyCombinations(timedCancellationSource.Token))
             {
                 if (dryRun)
                     continue;


### PR DESCRIPTION
The following (when run in osu-tools) will die in the new taiko code during diffcalc:
```
dotnet run -- difficulty 4328583 -r:1
```

This PR adds a timeout control to the server processor, initially set at a very lenient 30sec because it's shared amongst all mod combinations within a ruleset and includes beatmap loads/reloads.