### PR TITLE
Populate beatmap set `difficulty_names` after queued difficulty calculation completes

### DIFF
--- a/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
+++ b/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
@@ -98,7 +98,7 @@ namespace osu.Server.DifficultyCalculator.Commands
                             // ensure the correct online id is set
                             beatmap.BeatmapInfo.OnlineID = beatmapId;
 
-                            calc.Process(beatmap, ProcessingMode);
+                            calc.ProcessBeatmap(beatmap, ProcessingMode);
                             if (!NoNotifyProcessing)
                                 calc.NotifyBeatmapReprocessed(beatmapId);
 

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using Dapper;
 using MySqlConnector;
 using osu.Game.Beatmaps;
@@ -14,6 +15,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Scoring.Legacy;
+using osu.Game.Utils;
 using osu.Server.DifficultyCalculator.Commands;
 using osu.Server.QueueProcessor;
 
@@ -85,6 +87,50 @@ namespace osu.Server.DifficultyCalculator
                     {
                         beatmap_id = beatmapId,
                     });
+            }
+        }
+
+        public void ProcessBeatmapSet(long beatmapSetId)
+        {
+            if (dryRun)
+                return;
+
+            using (var conn = DatabaseAccess.GetConnection())
+            {
+                var beatmaps = conn.Query<osu_beatmap>(
+                                       @"SELECT `beatmap_id`, `diff_size`, `playmode`, `version`, `difficultyrating` FROM `osu_beatmaps` WHERE `beatmapset_id` = @setId",
+                                       new { setId = beatmapSetId })
+                                   .OrderBy(b => b.playmode).ThenBy(b => b.difficultyrating)
+                                   .ToArray();
+
+                var stringBuilder = new StringBuilder();
+
+                for (int i = 0; i < beatmaps.Length; i++)
+                {
+                    if (i > 0)
+                        stringBuilder.Append(',');
+
+                    var beatmap = beatmaps[i];
+
+                    if (beatmap.playmode == 3)
+                    {
+                        stringBuilder.Append('[');
+                        stringBuilder.Append(beatmap.diff_size);
+                        stringBuilder.Append("k] ");
+                    }
+
+                    stringBuilder.Append(beatmap.version.Replace(",", ""));
+                    stringBuilder.Append(" ★");
+                    stringBuilder.Append(FormatUtils.FormatStarRating(beatmap.difficultyrating).ToString());
+                    stringBuilder.Append('@');
+                    stringBuilder.Append(beatmap.playmode);
+                }
+
+                conn.Execute(@"UPDATE IGNORE `osu_beatmapsets` SET `difficulty_names` = @names WHERE `beatmapset_id` = @setId", new
+                {
+                    names = stringBuilder.ToString(),
+                    setId = beatmapSetId
+                });
             }
         }
 

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -69,20 +69,6 @@ namespace osu.Server.DifficultyCalculator
 
         public void ProcessBeatmapLegacyAttributes(WorkingBeatmap beatmap) => run(beatmap, processLegacyAttributes);
 
-        public void NotifyBeatmapSetReprocessed(long beatmapSetId)
-        {
-            if (dryRun)
-                return;
-
-            using (var conn = DatabaseAccess.GetConnection())
-            {
-                conn.Execute(@"INSERT INTO `bss_process_queue` (`beatmapset_id`, `status`) VALUES (@beatmapset_id, 2)", new
-                {
-                    beatmapset_id = beatmapSetId,
-                });
-            }
-        }
-
         public void NotifyBeatmapReprocessed(long beatmapId)
         {
             if (dryRun)
@@ -99,6 +85,20 @@ namespace osu.Server.DifficultyCalculator
                     {
                         beatmap_id = beatmapId,
                     });
+            }
+        }
+
+        public void NotifyBeatmapSetReprocessed(long beatmapSetId)
+        {
+            if (dryRun)
+                return;
+
+            using (var conn = DatabaseAccess.GetConnection())
+            {
+                conn.Execute(@"INSERT INTO `bss_process_queue` (`beatmapset_id`, `status`) VALUES (@beatmapset_id, 2)", new
+                {
+                    beatmapset_id = beatmapSetId,
+                });
             }
         }
 

--- a/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
+++ b/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs
@@ -43,21 +43,21 @@ namespace osu.Server.DifficultyCalculator
             }
         }
 
-        public void Process(WorkingBeatmap beatmap, ProcessingMode mode)
+        public void ProcessBeatmap(WorkingBeatmap beatmap, ProcessingMode mode)
         {
             switch (mode)
             {
                 case ProcessingMode.All:
-                    ProcessDifficulty(beatmap);
-                    ProcessLegacyAttributes(beatmap);
+                    ProcessBeatmapDifficulty(beatmap);
+                    ProcessBeatmapLegacyAttributes(beatmap);
                     break;
 
                 case ProcessingMode.Difficulty:
-                    ProcessDifficulty(beatmap);
+                    ProcessBeatmapDifficulty(beatmap);
                     break;
 
                 case ProcessingMode.ScoreAttributes:
-                    ProcessLegacyAttributes(beatmap);
+                    ProcessBeatmapLegacyAttributes(beatmap);
                     break;
 
                 default:
@@ -65,9 +65,9 @@ namespace osu.Server.DifficultyCalculator
             }
         }
 
-        public void ProcessDifficulty(WorkingBeatmap beatmap) => run(beatmap, processDifficulty);
+        public void ProcessBeatmapDifficulty(WorkingBeatmap beatmap) => run(beatmap, processDifficulty);
 
-        public void ProcessLegacyAttributes(WorkingBeatmap beatmap) => run(beatmap, processLegacyAttributes);
+        public void ProcessBeatmapLegacyAttributes(WorkingBeatmap beatmap) => run(beatmap, processLegacyAttributes);
 
         public void NotifyBeatmapSetReprocessed(long beatmapSetId)
         {

--- a/osu.Server.DifficultyCalculator/osu_beatmap.cs
+++ b/osu.Server.DifficultyCalculator/osu_beatmap.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Dapper.Contrib.Extensions;
+
+namespace osu.Server.DifficultyCalculator
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    [Table("osu_beatmaps")]
+    public class osu_beatmap
+    {
+        [ExplicitKey]
+        public uint beatmap_id { get; set; }
+
+        public float diff_size { get; set; }
+        public byte playmode { get; set; }
+        public string version { get; set; } = string.Empty;
+        public float difficultyrating { get; set; }
+    }
+}

--- a/osu.Server.Queues.BeatmapProcessor/BeatmapProcessor.cs
+++ b/osu.Server.Queues.BeatmapProcessor/BeatmapProcessor.cs
@@ -37,7 +37,7 @@ namespace osu.Server.Queues.BeatmapProcessor
                     // ensure the correct online id is set
                     working.BeatmapInfo.OnlineID = (int)beatmapId;
 
-                    calculator.Process(working, processingMode);
+                    calculator.ProcessBeatmap(working, processingMode);
                 }
 
                 calculator.NotifyBeatmapSetReprocessed(item.beatmapset_id);

--- a/osu.Server.Queues.BeatmapProcessor/BeatmapProcessor.cs
+++ b/osu.Server.Queues.BeatmapProcessor/BeatmapProcessor.cs
@@ -40,6 +40,7 @@ namespace osu.Server.Queues.BeatmapProcessor
                     calculator.ProcessBeatmap(working, processingMode);
                 }
 
+                calculator.ProcessBeatmapSet(item.beatmapset_id);
                 calculator.NotifyBeatmapSetReprocessed(item.beatmapset_id);
             }
         }


### PR DESCRIPTION
Notably this currently only does something in the normal "difficulty calculation queued via redis" case. The commands don't attempt to run this logic. The reason is that it's going to be very annoying to make that work because the commands are based on beatmap IDs and not beatmap set IDs, and I don't know that it's worth the time investment to have this be 100% absolutely correct even after a rework or a manual fix via the commands.

I'm basically putting this out because I was prepared to do this work in order to fix the issue but lost confidence midway through, and there are possible five other ways of fixing this issue that may be preferable at this stage.