### PR TITLE
Allow calculation runs to use data.ppy.sh as a seed for cache

### DIFF
--- a/osu.Server.DifficultyCalculator/AppSettings.cs
+++ b/osu.Server.DifficultyCalculator/AppSettings.cs
@@ -23,6 +23,11 @@ namespace osu.Server.DifficultyCalculator
         public static readonly string BEATMAPS_PATH;
 
         /// <summary>
+        /// Whether to verify the retrieved or cached `.osu` file matches database hashes before running processing.
+        /// </summary>
+        public static readonly bool VERIFY_BEATMAP_HASHES;
+
+        /// <summary>
         /// Whether beatmaps should be downloaded if they don't exist in <see cref="BEATMAPS_PATH"/>.
         /// </summary>
         public static readonly bool ALLOW_DOWNLOAD;
@@ -44,6 +49,8 @@ namespace osu.Server.DifficultyCalculator
             SKIP_INSERT_ATTRIBUTES = Environment.GetEnvironmentVariable("SKIP_INSERT_ATTRIBUTES") == "1";
             ALLOW_DOWNLOAD = Environment.GetEnvironmentVariable("ALLOW_DOWNLOAD") == "1";
             SAVE_DOWNLOADED = Environment.GetEnvironmentVariable("SAVE_DOWNLOADED") == "1";
+
+            VERIFY_BEATMAP_HASHES = Environment.GetEnvironmentVariable("VERIFY_BEATMAP_HASHES") == "1";
 
             BEATMAPS_PATH = Environment.GetEnvironmentVariable("BEATMAPS_PATH") ?? "osu";
             DOWNLOAD_PATH = Environment.GetEnvironmentVariable("BEATMAP_DOWNLOAD_PATH") ?? "https://osu.ppy.sh/osu/{0}";

--- a/osu.Server.DifficultyCalculator/AppSettings.cs
+++ b/osu.Server.DifficultyCalculator/AppSettings.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.IO;
 
 namespace osu.Server.DifficultyCalculator
 {
@@ -21,6 +22,11 @@ namespace osu.Server.DifficultyCalculator
         /// A full or relative path used to store beatmaps.
         /// </summary>
         public static readonly string BEATMAPS_PATH;
+
+        /// <summary>
+        /// Whether beatmaps should be downloaded from https://data.ppy.sh to seed the operation.
+        /// </summary>
+        public static readonly bool ALLOW_SEEDED_DOWNLOAD;
 
         /// <summary>
         /// Whether to verify the retrieved or cached `.osu` file matches database hashes before running processing.
@@ -50,10 +56,14 @@ namespace osu.Server.DifficultyCalculator
             ALLOW_DOWNLOAD = Environment.GetEnvironmentVariable("ALLOW_DOWNLOAD") == "1";
             SAVE_DOWNLOADED = Environment.GetEnvironmentVariable("SAVE_DOWNLOADED") == "1";
 
+            ALLOW_SEEDED_DOWNLOAD = Environment.GetEnvironmentVariable("ALLOW_SEEDED_DOWNLOAD") == "1";
             VERIFY_BEATMAP_HASHES = Environment.GetEnvironmentVariable("VERIFY_BEATMAP_HASHES") == "1";
 
             BEATMAPS_PATH = Environment.GetEnvironmentVariable("BEATMAPS_PATH") ?? "osu";
             DOWNLOAD_PATH = Environment.GetEnvironmentVariable("BEATMAP_DOWNLOAD_PATH") ?? "https://osu.ppy.sh/osu/{0}";
+
+            if (SAVE_DOWNLOADED && !Directory.Exists(BEATMAPS_PATH))
+                Directory.CreateDirectory(BEATMAPS_PATH);
         }
     }
 }

--- a/osu.Server.DifficultyCalculator/BeatmapLoader.cs
+++ b/osu.Server.DifficultyCalculator/BeatmapLoader.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Framework.Audio.Track;
@@ -18,11 +20,98 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Skinning;
 using osu.Server.QueueProcessor;
+using SharpCompress.Archives.Tar;
+using SharpCompress.Compressors;
+using SharpCompress.Compressors.BZip2;
 
 namespace osu.Server.DifficultyCalculator
 {
     public static class BeatmapLoader
     {
+        public static void PopulateCacheWithSeededFiles(IReporter? reporter = null)
+        {
+            reporter?.Output("Populating local cache from seeded beatmaps...");
+
+            var req = new WebRequest("https://data.ppy.sh/");
+            req.Perform();
+            string response = req.GetResponseString()!;
+            var matches = Regex.Matches(response, "[0-9]+_[0-9]+_[0-9]+_osu_files.tar.bz2");
+
+            var tarBz2Filename = matches.Last().Value;
+
+            // If the archive is present locally and cache has many files, assume it's already been extracted for simplicity.
+            int localBeatmaps = Directory.GetFiles(AppSettings.BEATMAPS_PATH).Length;
+
+            if (File.Exists(tarBz2Filename) && localBeatmaps > 10000)
+            {
+                reporter?.Output($"Found {tarBz2Filename} locally and populated cache ({localBeatmaps:N0} files), assuming cache is populated already.");
+                reporter?.Output("Delete this file to repopulate cache.");
+                return;
+            }
+
+            string tarFilename = tarBz2Filename.Replace(".bz2", string.Empty);
+
+            try
+            {
+                if (!File.Exists(tarBz2Filename))
+                {
+                    req = new FileWebRequest(tarBz2Filename, $"https://data.ppy.sh/{tarBz2Filename}");
+                    int? progress = null;
+                    req.DownloadProgress += (current, total) =>
+                    {
+                        int roundedProgress = (int)((double)current / total * 100);
+
+                        if (progress != roundedProgress)
+                        {
+                            if (roundedProgress == 0)
+                                reporter?.Verbose($"Downloading {tarBz2Filename}... {total / 1048576:N0} mb");
+                            else if (roundedProgress % 10 == 0)
+                                reporter?.Verbose($"Downloading {tarBz2Filename}... {roundedProgress}%");
+                        }
+
+                        progress = roundedProgress;
+                    };
+                    req.Perform();
+                }
+
+                if (!File.Exists(tarFilename))
+                {
+                    reporter?.Verbose($"Extracting {tarBz2Filename}...");
+
+                    using (var stream = File.OpenRead(tarBz2Filename))
+                    using (var outStream = File.Create(tarFilename))
+                    using (var bz2 = BZip2Stream.Create(stream, CompressionMode.Decompress, false))
+                        bz2.CopyTo(outStream);
+                }
+
+                using var archive = TarArchive.OpenArchive(tarFilename);
+
+                foreach (var entry in archive.Entries)
+                {
+                    if (entry.Size == 0)
+                        continue;
+
+                    string filename = Path.GetFileName(entry.Key!);
+
+                    reporter?.Verbose($"Extracting {filename}...");
+
+                    using (var outStream = File.Create(Path.Combine(AppSettings.BEATMAPS_PATH, filename)))
+                    using (var stream = entry.OpenEntryStream())
+                        stream.CopyTo(outStream);
+                }
+            }
+            catch
+            {
+                // If any error occurs, delete the archive to allow a retry next run.
+                File.Delete(tarBz2Filename);
+                throw;
+            }
+            finally
+            {
+                File.Delete(tarFilename);
+            }
+        }
+
         public static WorkingBeatmap GetBeatmap(int beatmapId, bool verbose = false, IReporter? reporter = null)
         {
             string fileLocation = Path.Combine(AppSettings.BEATMAPS_PATH, beatmapId.ToString()) + ".osu";

--- a/osu.Server.DifficultyCalculator/BeatmapLoader.cs
+++ b/osu.Server.DifficultyCalculator/BeatmapLoader.cs
@@ -23,7 +23,7 @@ namespace osu.Server.DifficultyCalculator
 {
     public static class BeatmapLoader
     {
-        public static WorkingBeatmap GetBeatmap(int beatmapId, bool verbose = false, bool forceDownload = true, IReporter? reporter = null)
+        public static WorkingBeatmap GetBeatmap(int beatmapId, bool verbose = false, IReporter? reporter = null)
         {
             string fileLocation = Path.Combine(AppSettings.BEATMAPS_PATH, beatmapId.ToString()) + ".osu";
 
@@ -52,7 +52,7 @@ namespace osu.Server.DifficultyCalculator
                 }
             }
 
-            if ((forceDownload || !cachedBeatmapValid) && AppSettings.ALLOW_DOWNLOAD)
+            if (!cachedBeatmapValid && AppSettings.ALLOW_DOWNLOAD)
             {
                 if (verbose)
                     reporter?.Verbose($"Downloading {beatmapId}.");

--- a/osu.Server.DifficultyCalculator/BeatmapLoader.cs
+++ b/osu.Server.DifficultyCalculator/BeatmapLoader.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.IO;
+using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Framework.Audio.Track;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Network;
 using osu.Game.Beatmaps;
@@ -15,6 +17,7 @@ using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Skinning;
+using osu.Server.QueueProcessor;
 
 namespace osu.Server.DifficultyCalculator
 {
@@ -24,7 +27,32 @@ namespace osu.Server.DifficultyCalculator
         {
             string fileLocation = Path.Combine(AppSettings.BEATMAPS_PATH, beatmapId.ToString()) + ".osu";
 
-            if ((forceDownload || !File.Exists(fileLocation)) && AppSettings.ALLOW_DOWNLOAD)
+            bool cachedBeatmapValid = File.Exists(fileLocation);
+
+            if (cachedBeatmapValid && AppSettings.VERIFY_BEATMAP_HASHES)
+            {
+                using (var conn = DatabaseAccess.GetConnection())
+                {
+                    using (var stream = File.OpenRead(fileLocation))
+                    {
+                        string localHash = stream.ComputeMD5Hash();
+                        string serverHash = conn.QuerySingle<string>("SELECT checksum FROM osu_beatmaps WHERE beatmap_id = @beatmap_id", new
+                        {
+                            beatmap_id = beatmapId
+                        });
+
+                        if (localHash != serverHash)
+                        {
+                            reporter?.Warn($"Checksum didn't match for {beatmapId}, ignoring cache");
+
+                            File.Delete(fileLocation);
+                            cachedBeatmapValid = false;
+                        }
+                    }
+                }
+            }
+
+            if ((forceDownload || !cachedBeatmapValid) && AppSettings.ALLOW_DOWNLOAD)
             {
                 if (verbose)
                     reporter?.Verbose($"Downloading {beatmapId}.");
@@ -66,7 +94,7 @@ namespace osu.Server.DifficultyCalculator
                 return new LoaderWorkingBeatmap(stream);
             }
 
-            if (!File.Exists(fileLocation))
+            if (!cachedBeatmapValid)
                 throw new Exception("Beatmap file does not exist and was not downloaded.");
 
             return new LoaderWorkingBeatmap(fileLocation);

--- a/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
+++ b/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
@@ -26,7 +26,9 @@ namespace osu.Server.DifficultyCalculator.Commands
         [Option(CommandOptionType.SingleValue, Template = "-c|--concurrency", Description = "Number of threads to use. Default 1.")]
         public int Concurrency { get; set; } = 1;
 
-        [Option(CommandOptionType.NoValue, Template = "--no-notify", Description = "Don't notify of beatmap reprocessing via `bss_process_queue` table. This should only be used when a full score reprocess is to be queued after difficulty calculator re-run.")]
+        [Option(CommandOptionType.NoValue, Template = "--no-notify",
+            Description =
+                "Don't notify of beatmap reprocessing via `bss_process_queue` table. This should only be used when a full score reprocess is to be queued after difficulty calculator re-run.")]
         public bool NoNotifyProcessing { get; set; }
 
         [Option(CommandOptionType.NoValue, Template = "-v|--verbose", Description = "Provide verbose console output.")]
@@ -68,6 +70,9 @@ namespace osu.Server.DifficultyCalculator.Commands
             }
 
             threadBeatmapIds = new int[Concurrency];
+
+            if (AppSettings.ALLOW_SEEDED_DOWNLOAD)
+                BeatmapLoader.PopulateCacheWithSeededFiles(reporter);
 
             var beatmaps = new ConcurrentQueue<int>(GetBeatmaps());
 

--- a/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
+++ b/osu.Server.DifficultyCalculator/Commands/CalculatorCommand.cs
@@ -29,9 +29,6 @@ namespace osu.Server.DifficultyCalculator.Commands
         [Option(CommandOptionType.NoValue, Template = "--no-notify", Description = "Don't notify of beatmap reprocessing via `bss_process_queue` table. This should only be used when a full score reprocess is to be queued after difficulty calculator re-run.")]
         public bool NoNotifyProcessing { get; set; }
 
-        [Option(CommandOptionType.NoValue, Template = "-d|--force-download", Description = "Force download of all beatmaps.")]
-        public bool ForceDownload { get; set; }
-
         [Option(CommandOptionType.NoValue, Template = "-v|--verbose", Description = "Provide verbose console output.")]
         public bool Verbose { get; set; }
 
@@ -93,7 +90,7 @@ namespace osu.Server.DifficultyCalculator.Commands
 
                         try
                         {
-                            var beatmap = BeatmapLoader.GetBeatmap(beatmapId, Verbose, ForceDownload, reporter);
+                            var beatmap = BeatmapLoader.GetBeatmap(beatmapId, Verbose, reporter);
 
                             // ensure the correct online id is set
                             beatmap.BeatmapInfo.OnlineID = beatmapId;

--- a/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
+++ b/osu.Server.DifficultyCalculator/osu.Server.DifficultyCalculator.csproj
@@ -17,11 +17,11 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.10" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />
         <PackageReference Include="MySqlConnector" Version="2.4.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2025.1029.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2025.1029.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2025.1029.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2025.1029.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2025.1029.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2026.621.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.621.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2026.621.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2026.621.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2026.621.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2025.317.0" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
This was already [being done](https://github.com/ppy/osu/blob/master/.github/workflows/_diffcalc_processor.yml#L178-L185) by the github actions runner, but I think it's valuable to have this functionality local for self runs.

Additional, this setup can also now be used on production thanks to the additional hash check, which will forcefully download a beatmap if the hash doesn't match:

```
[6/30/2026 7:11:39 AM]: Processed 41 / 229938 (16/sec)
[6/30/2026 7:11:40 AM]: Processed 53 / 229938 (12/sec)
[6/30/2026 7:11:40 AM]: Hash didn't match for 186, ignoring cache
[network] 2026-06-30 07:11:41 [verbose]: Request to https://osu.ppy.sh/osu/186 successfully completed!
[6/30/2026 7:11:41 AM]: Processed 67 / 229938 (14/sec)
[6/30/2026 7:11:42 AM]: Threads 0:218 1:184 2:187 3:214 4:183 5:220 6:215 7:186 8:174 9:196 10:193 11:209 12:204 13:210 14:217 15:203 16:198 17:208 18:212 19:216 
[6/30/2026 7:11:42 AM]: Processed 78 / 229938 (11/sec)
```

Around 20 gb of disk space should be free to allow for the extraction of the files.